### PR TITLE
Adding git as dependency on install documentation

### DIFF
--- a/debian/cyborgbackup.preinst
+++ b/debian/cyborgbackup.preinst
@@ -5,7 +5,7 @@ set -e
 
 case "$1" in 
   install|upgrade|configure)
-      if ! getent passwd cyborgbackup > /dev:null ; then
+      if ! getent passwd cyborgbackup > /dev/null ; then
          useradd -m -d /opt/cyborgbackup -s /bin/bash cyborgbackup
       fi
       if test -f /etc/supervisor/conf.d/cyborgbackup.conf ; then

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -11,7 +11,7 @@ Debian Package
 
 A debian package have been build with CyBorgBackup latest release and can be downloaded from Releases github page::
 
-    # apt install postgresql-all elasticsearch rabbitmq-server python3-pip python3-virtualenv python3-setuptools python3-venv supervisor nginx
+    # apt install postgresql-all elasticsearch rabbitmq-server python3-pip python3-virtualenv python3-setuptools python3-venv supervisor nginx git
     # dpkg -i cyborgbackup_X.X.X_all.deb
 
 $ docker-compose up


### PR DESCRIPTION
As I was installing cyborgbackup following the install documentation, on a fresh Debian 10, it appears that git was missing.