### PR TITLE
Fix bug where catalog is no longer filled

### DIFF
--- a/src/cyborgbackup/main/tasks.py
+++ b/src/cyborgbackup/main/tasks.py
@@ -1289,6 +1289,8 @@ class RunJob(BaseTask):
                     archive_name = job_stdout.split(':')[1].strip()
                 if not archive_name:
                     raise Exception("Latest backup haven't archive name in the report")
+                master_job.archive_name = archive_name
+                master_job.save()
                 base_script = os.path.join(settings.SCRIPTS_DIR, 'cyborgbackup', 'fill_catalog')
                 with open(base_script) as fs:
                     script = fs.read()


### PR DESCRIPTION
After the 0.4 update, the catalog is no longer filled.
This commit fixes this problem, by assigning the right value to the job.