### PR TITLE
Fixed missing borgbackup install needed inside docker containers for various jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DOCKER_CONTAINER 1
 
 COPY ./requirements.txt /cyborgbackup/requirements.txt
 RUN pip install -r /cyborgbackup/requirements.txt
+RUN apt-get update && apt-get install -y borgbackup
 
 COPY ./src/ /cyborgbackup/
 


### PR DESCRIPTION
Some jobs (specifically prune and some catalog) need borg installed within the docker in order to run.

Should  also fix #54 